### PR TITLE
Fix issue with no _member_count

### DIFF
--- a/statcord/__init__.py
+++ b/statcord/__init__.py
@@ -2,7 +2,7 @@ __title__ = 'statcord.py'
 __author__ = 'statcord.com'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2020, statcord.com'
-__version__ = '3.0.5'
+__version__ = '3.0.6'
 
 name = "statcord"
 
@@ -11,4 +11,4 @@ from .client import Client
 from .exceptions import *
 
 VersionInfo = namedtuple('VersionInfo', 'major minor micro releaselevel serial')
-version_info = VersionInfo(major=3, minor=0, micro=5, releaselevel='final', serial=0)
+version_info = VersionInfo(major=3, minor=0, micro=6, releaselevel='final', serial=0)

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -85,7 +85,10 @@ class Client:
 
     @property
     def users(self):
-        return str(sum(g.member_count for g in self.bot.guilds))
+        try:
+            return str(sum(g.member_count for g in self.bot.guilds))
+        except:
+            return len(self.bot.user)
 
     async def post_data(self):
         id = str(self.bot.user.id)

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -88,7 +88,7 @@ class Client:
         try:
             return str(sum(g.member_count for g in self.bot.guilds))
         except:
-            return len(self.bot.user)
+            return len(self.bot.users)
 
     async def post_data(self):
         id = str(self.bot.user.id)


### PR DESCRIPTION
A TEMPORARY fix to the issue with guild._member_count being null, simply just falls back to the cached user count.