### PR TITLE
Allow loop to be cancelled

### DIFF
--- a/statcord/client.py
+++ b/statcord/client.py
@@ -195,6 +195,9 @@ class Client:
         if self._task:
             return self._task.cancel()
 
+    def __del__(self):
+        self.stop_loop()
+
     def command_run(self, ctx: Context) -> None:
         self.commands += 1
         if ctx.author.id not in self.active:

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -206,23 +206,23 @@ class Client:
         else:
             self.popular.append({"name": command, "count": "1"})
 
-async def __loop(self) -> None:
-    """
-    The internal loop used for automatically posting server/guild count stats
-    """
-    await self.bot.wait_until_ready()
-    if self.debug:
-        self.logger.debug("Statcord Auto Post has started!")
-    while not self.bot.is_closed():
-        self.logger.debug("Posting stats...")
-        try:
-            await self.post_data()
-        except Exception as e:
-            self.logger.debug("Got error, dispatching error handlers.")
-            await self.on_error(e)
-        else:
-            self.logger.debug("Posted stats successfully.")
-        await asyncio.sleep(60)
+    async def __loop(self) -> None:
+        """
+        The internal loop used for automatically posting server/guild count stats
+        """
+        await self.bot.wait_until_ready()
+        if self.debug:
+            self.logger.debug("Statcord Auto Post has started!")
+        while not self.bot.is_closed():
+            self.logger.debug("Posting stats...")
+            try:
+                await self.post_data()
+            except Exception as e:
+                self.logger.debug("Got error, dispatching error handlers.")
+                await self.on_error(e)
+            else:
+                self.logger.debug("Posted stats successfully.")
+            await asyncio.sleep(60)
 
-    async def on_error(self, error: BaseException) -> None:
-        self.logger.exception("Statcord posting exception occurred.", exc_info=error)
+        async def on_error(self, error: BaseException) -> None:
+            self.logger.exception("Statcord posting exception occurred.", exc_info=error)

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -183,7 +183,7 @@ class Client:
     def is_loop_running(self) -> bool:
         if not self._task:
             return False  # Task hasn't been created.
-        return not self._task.cancelled
+        return not self._task.cancelled()
 
     @is_loop_running.setter
     def is_loop_running(self, value) -> bool:

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -177,6 +177,8 @@ class Client:
             await self.__handle_response(resp)
 
     def start_loop(self) -> None:
+        if self._task:
+            raise RuntimeError("A loop is already running.")
         self._task = self.bot.loop.create_task(self.__loop())
 
     @property

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -177,7 +177,7 @@ class Client:
             await self.__handle_response(resp)
 
     def start_loop(self) -> None:
-        if self._task:
+        if self._task and (not self._task.cancelled()):
             raise RuntimeError("A loop is already running.")
         self._task = self.bot.loop.create_task(self.__loop())
 
@@ -192,7 +192,7 @@ class Client:
         raise RuntimeError("Not allowed to edit this property.")
 
     def stop_loop(self) -> bool:
-        if self._task:
+        if self._task and (not self._task.cancelled()):
             return self._task.cancel()
 
     def __del__(self):

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -185,7 +185,7 @@ class Client:
             return False  # Task hasn't been created.
         return not self._task.cancelled
 
-    @property.setter
+    @is_loop_running.setter
     def is_loop_running(self) -> bool:
         raise RuntimeError("Not allowed to edit this property.")
 

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -186,7 +186,7 @@ class Client:
         return not self._task.cancelled
 
     @is_loop_running.setter
-    def is_loop_running(self) -> bool:
+    def is_loop_running(self, value) -> bool:
         raise RuntimeError("Not allowed to edit this property.")
 
     def stop_loop(self) -> bool:

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -183,9 +183,9 @@ class Client:
 
     @property
     def is_loop_running(self) -> bool:
-        if not self._task:
-            return False  # Task hasn't been created.
-        return not self._task.cancelled()
+        if self._task:
+            return not self._task.cancelled()
+        return False  # Task hasn't been created.
 
     @is_loop_running.setter
     def is_loop_running(self, value) -> bool:

--- a/statcord/client.py
+++ b/statcord/client.py
@@ -226,5 +226,5 @@ class Client:
                 self.logger.debug("Posted stats successfully.")
             await asyncio.sleep(60)
 
-        async def on_error(self, error: BaseException) -> None:
-            self.logger.exception("Statcord posting exception occurred.", exc_info=error)
+    async def on_error(self, error: BaseException) -> None:
+        self.logger.exception("Statcord posting exception occurred.", exc_info=error)


### PR DESCRIPTION
This allow the bot to cancel an ongoing task without killing/closing the bot itself. Useful for when unloading a cog.
