### PR TITLE
Added Slash Command Support

### DIFF
--- a/statcord/client.py
+++ b/statcord/client.py
@@ -194,7 +194,21 @@ class Client:
             break
         else:
             self.popular.append({"name": command, "count": "1"})
+                                
+    def slash_command_run(self, ctx: Context) -> None:
+        self.commands += 1
+        if ctx.author.id not in self.active:
+            self.active.append(ctx.author.id)
 
+        command = ctx.name
+        self.logger.debug(f"Command {command} has been run by {ctx.author.id}")
+        for cmd in filter(lambda x: x["name"] == command, self.popular):
+            cmd["count"] = str(int(cmd["count"]) + 1)
+            break
+        else:
+            self.popular.append({"name": command, "count": "1"})                         
+
+                                
     async def __loop(self) -> None:
         """
         The internal loop used for automatically posting server/guild count stats


### PR DESCRIPTION
When you use the `command_run` on the `on_slash_command` event, it does not work, as slash commands to not register their name in that format, the new function, `slash_command_start` will fix that.